### PR TITLE
Fixing bootstrap script

### DIFF
--- a/lab/ec2-instance-bootstrapping/webserver-02.sh
+++ b/lab/ec2-instance-bootstrapping/webserver-02.sh
@@ -13,4 +13,4 @@ curl http://169.254.169.254/latest/meta-data/public-ipv4 >> /var/www/html/index.
 echo '</h3> <h3>Local IP: ' >> /var/www/html/index.html
 curl http://169.254.169.254/latest/meta-data/local-ipv4 >> /var/www/html/index.html
 echo '</h3></html> ' >> /var/www/html/index.html
-apt-get install mysql-server
+apt-get install mysql-server -y


### PR DESCRIPTION
The script cannot automatically install MySQL Server, it needs to include the parameter to accept the modifications (-y).